### PR TITLE
Fix travis.yml to install babel-register

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "v4.0.0"
 before_script:
+  - npm install --save-dev babel-register
   - npm install -g mocha


### PR DESCRIPTION
**issue**
Pull Request couldn't passed by TravisCI

**reason**
babel-register is not installed.
``` bash
error Couldn't find the binary mocha --require babel-register
```

**solution**
install babel-register on before_script
``` yml
npm install --save-dev babel-register
```